### PR TITLE
Modifications for nexus-constructor

### DIFF
--- a/eniius/mcstas.py
+++ b/eniius/mcstas.py
@@ -248,22 +248,22 @@ class McStasComp2NX():
 
         self.nxobj['mcstas'] = json.dumps(kwargs)
 
-        self.nxobj['transforms'] = transforms
+        self.nxobj['transformations'] = transforms
         most_dependent = _outer_transform_dependency(transforms)
 
         for name, insert in _decode_component_eniius_data(mcstas_comp, only_nx=only_nx).items():
             self.nxobj[name] = insert
             # if transforms/name but not, e.g., transforms/name/value
-            if 'transforms' in name and name.count('/') == 1:
+            if 'transformations' in name and name.count('/') == 1:
                 # add the same-level dependnecy link to the just-set transformation, if it doesn't have one already
                 # to allow for possibly overwriting an existing transformation
                 if not hasattr(self.nxobj[name], 'depends_on'):
                     self.nxobj[name].attrs['depends_on'] = most_dependent
                 # since we may have overwritten or added a transformation, work out the dependency chain again
-                most_dependent = _outer_transform_dependency(self.nxobj['transforms'])
+                most_dependent = _outer_transform_dependency(self.nxobj['transformations'])
 
         # set the object level dependency (not an attribute!) only now, in case it changed
-        self.nxobj['depends_on'] = f'transforms/{most_dependent}'
+        self.nxobj['depends_on'] = f'transformations/{most_dependent}'
 
     @classmethod
     def getNXtype(cls, comp):
@@ -472,7 +472,7 @@ class AffineRotate():
             if distance > 1e-5:
                 vec /= distance
             return NXfield(distance, vector=vec, depends_on=self.depends_on,
-                           transformation_type='translation', units='metre')
+                           transformation_type='translation', units='m')
         else:
             # If transformation has a rotation, include translation as offset
             axis, angle = self.axisrot()
@@ -613,7 +613,7 @@ class NXMcStas():
         mcpars = {p: mcstasscript_parameter_name_or_value(getattr(comp, p)) for p in comp.parameter_names if getattr(comp, p) is not None}
 
         nxcomp = McStasComp2NX(comp, order, self.NXtransformations(name), only_nx=only_nx, **mcpars)
-        if nxcomp.nxobj['transforms'] != self.NXtransformations(name):
+        if nxcomp.nxobj['transformations'] != self.NXtransformations(name):
             # the component updated the transforms NXtransformations group
             # invalidate the associated affinelist to avoid using the wrong position?
             self.affinelist[name] = None

--- a/eniius/writer.py
+++ b/eniius/writer.py
@@ -57,14 +57,16 @@ def conv_types(obj, only_nx=True):
             raise RuntimeError(f'unrecognised type {typ} / {dtyp}')
     else:
         (tp, vl) = (dtyp.name, obj)
-    if tp == 'int64':
-        tp = 'int'
-    elif tp == 'str':
+    if tp == 'str':
         tp = 'string'
     elif tp == 'float64':
-        tp = 'float'
+        tp = 'double'
     elif tp == 'object':
         raise RuntimeError('Internal logical error')
+    elif tp == 'int':
+        tp = 'int64'
+    elif tp == 'float':
+        tp = 'double'
     return tp, vl
 
 
@@ -74,7 +76,7 @@ class Writer:
     """
 
     def __init__(self, nxobj):
-        self.rootname = 'root'
+        self.rootname = 'entry'
         self.data = None
         self.sample = None
         self.nxobj = None
@@ -208,7 +210,7 @@ class Writer:
             fd = {f'number_of_{fnm}': NXfield(np.array(len(idx), dtype='uint64'))}
             fd['detector_number'] = NXfield(detdat[idx,0].astype(np.int32))
             fd['detector_offset'] = NXfield(detdat[idx,1])
-            fd['distance'] = NXfield(detdat[idx,2], units='metre')
+            fd['distance'] = NXfield(detdat[idx,2], units='m')
             fd['polar_angle'] = NXfield(detdat[idx,4], units='degree')
             fd['azimuthal_angle'] = NXfield(detdat[idx,5], units='degree')
             fd['user_table_titles'] = NXfield(titles)

--- a/test/one_slit_explicit.instr
+++ b/test/one_slit_explicit.instr
@@ -6,9 +6,9 @@ COMPONENT Origin = Arm()
 COMPONENT slit = Slit(xmin=-1, xmax=0.2, ymin=0.0, ymax=10) AT (0, 0, 10) RELATIVE Origin
 EXTEND %{
 char* slit_eniius_data =
-"{'transforms/x': {'type': 'NXfield', 'value': -0.4,"
+"{'transformations/x': {'type': 'NXfield', 'value': -0.4,"
 "      'attributes': {'units': 'm', 'transformation_type': 'translation', 'vector': [1, 0, 0], 'depends_on': 'slit0'}},"
-" 'transforms/y': {'type': 'NXfield', 'value': 5.0,"
+" 'transformations/y': {'type': 'NXfield', 'value': 5.0,"
 "      'attributes': {'units': 'm', 'transformation_type': 'translation', 'vector': [0, 1, 0]}}"
 "}";
 %}

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -39,8 +39,8 @@ class EniiusTest(unittest.TestCase):
             self.assertTrue(isinstance(comp1['mcstas']._value, np.ndarray))
             self.assertTrue(isinstance(comp1['mcstas']._value, np.ndarray))
             self.assertEqual(comp1['mcstas']._value.dtype.kind, 'S')
-            self.assertTrue('transforms' in comp1)
-            self.assertTrue(isinstance(comp1['transforms'], nexus.NXtransformations))
+            self.assertTrue('transformations' in comp1)
+            self.assertTrue(isinstance(comp1['transformations'], nexus.NXtransformations))
 
     def test_save_nxspe_from_merlin(self):
         Ei = 180.
@@ -89,7 +89,7 @@ class EniiusTest(unittest.TestCase):
         root = children[0]
         for field in nx_class_fields:
             self.assertTrue(field in root)
-        self.assertTrue('root' == root['name'])
+        self.assertTrue('entry' == root['name'])
         self.assertTrue(len(root['children']) == 1)
         self.assertTrue(len(root['attributes']) == 1)
         self.assertTrue(root['attributes'][0]['values'] == 'NXentry')
@@ -140,7 +140,7 @@ class EniiusTest(unittest.TestCase):
         root = children[0]
         for field in nx_class_fields:
             self.assertTrue(field in root)
-        self.assertTrue('root' == root['name'])
+        self.assertTrue('entry' == root['name'])
         self.assertTrue(len(root['children']) == 1)
         self.assertTrue(len(root['attributes']) == 1)
         self.assertTrue(root['attributes'][0]['values'] == 'NXentry')


### PR DESCRIPTION
I'm trying to produce a JSON file that nexus-constructor can read and have identified some issues that _seem_ to be a problem. Those are:
- the group holding NXtransformations must be called 'transformations' for nexus-constructor to recognize it.
- the root group _might_ need to be named 'entry' instead of 'root'
- integer valued entries can not have type 'int', but instead one of 'int16', 'int32', 'int64', 'uint16', 'uint32', 'uint64'
- floating point valued entries may not be recognized correctly unless their type is 'double' instead of 'float'
- distances with units of metres/meters _might_ only be recognized if 'm' is used instead.

This PR includes those changes, and enables a very simple instrument to be loaded by nexus-constructor.
A more complicated instrument does not load, but the reason for this remains unclear.
I can try and investigate the more complicated case before merging this PR, if you think that's worthwhile.

Are these changes problematic for the integration with Horace? If so, I can think about a better way to implement them.